### PR TITLE
processor-architecture sensible kit default path

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -126,7 +126,7 @@ function wizardSetup (program) {
       name: 'windowsKit',
       type: 'input',
       message: "Please enter the location of your Windows Kit's bin folder: ",
-      default: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x64',
+      default: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\' + (process.arch === 'ia32' ? 'x86' : 'x64'),
       when: () => (!program.windowsKit)
     }
   ]


### PR DESCRIPTION
Use x86 bin folder (Windows Kit) on x86 systems.