### PR TITLE
Clarified input for "package name"

### DIFF
--- a/lib/params.js
+++ b/lib/params.js
@@ -62,7 +62,7 @@ module.exports = function (program) {
       {
         name: 'packageName',
         type: 'input',
-        message: "Please enter your app's package name (name of your exe): ",
+        message: "Please enter your app's package name (name of your exe - without '.exe'): ",
         when: () => (!program.packageName)
       },
       {


### PR DESCRIPTION
I entered "MyApp.exe" and wondered why it failed - went through the error message and deduced that it probably should be without the ".exe". Hope this prevents others from doing the same mistake as I did.