### PR TITLE
Publisher display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ These are all options for the CLI:
   -m, --manifest <manifestPath>              Path to a manifest, if you want to be overwritten
   -d, --deploy <true|false>                  Should the app be deployed after creation?
   --publisher <publisher>                    Publisher to use (example: CN=developmentca)
+  --publisher-display-name <publisherDisplayName> Publisher display name to use
   --windows-kit <windows-kit>                Path to the Windows Kit bin folder
   --dev-cert <dev-cert>                      Path to the developer certificate to use
   --desktop-converter <desktop-converter>    Path to the desktop converter tools

--- a/bin/windowsstore.js
+++ b/bin/windowsstore.js
@@ -36,6 +36,7 @@ program
   .option('-m, --manifest <manifestPath>', 'Path to a manifest, if you want to overwrite the default one')
   .option('-d, --deploy <true|false>', 'Should the app be deployed after creation?')
   .option('--publisher <publisher>', 'Publisher to use (example: CN=developmentca)')
+  .option('--publisher-display-name <publisherDisplayName', 'Publisher display name to use')
   .option('--windows-kit <windows-kit>', 'Path to the Windows Kit bin folder')
   .option('--dev-cert <dev-cert>', 'Path to the developer certificate to use')
   .option('--desktop-converter <desktop-converter>', 'Path to the desktop converter tools')

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -132,7 +132,7 @@ function convertWithFileCopy (program) {
       }
 
       result = result.replace(/\${publisherName}/g, program.publisher)
-      result = result.replace(/\${publisherDisplayName}/g, program.publisherDisplayName)
+      result = result.replace(/\${publisherDisplayName}/g, program.publisherDisplayName || 'Reserved')
       result = result.replace(/\${packageVersion}/g, program.packageVersion)
       result = result.replace(/\${packageName}/g, program.packageName)
       result = result.replace(/\${packageExecutable}/g, executable)

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -132,6 +132,7 @@ function convertWithFileCopy (program) {
       }
 
       result = result.replace(/\${publisherName}/g, program.publisher)
+      result = result.replace(/\${publisherDisplayName}/g, program.publisherDisplayName)
       result = result.replace(/\${packageVersion}/g, program.packageVersion)
       result = result.replace(/\${packageName}/g, program.packageName)
       result = result.replace(/\${packageExecutable}/g, executable)

--- a/template/appxmanifest.xml
+++ b/template/appxmanifest.xml
@@ -9,7 +9,7 @@
     Version="${packageVersion}" />
   <Properties>
     <DisplayName>${packageDisplayName}</DisplayName>
-    <PublisherDisplayName>Reserved</PublisherDisplayName>
+    <PublisherDisplayName>${publisherDisplayName}</PublisherDisplayName>
     <Description>No description entered</Description>
     <Logo>assets\SampleAppx.50x50.png</Logo>
   </Properties>


### PR DESCRIPTION
When submitting to Windows Store errors were given to me because the manifest contained value of "Reserved" in the "PublisherDisplayName" rather than a value matching my account publisher name. Looking through issues it seems I'm not the only one affected. This adds an optional command arg to specify a PublisherDisplayName.