### PR TITLE
Add makecert option to skip certificate installation

### DIFF
--- a/lib/sign.js
+++ b/lib/sign.js
@@ -47,6 +47,7 @@ const isValidPublisherName = (function () {
 function makeCert (parametersOrPublisherName, certFilePath, program) {
   let publisherName
   let certFileName
+  let install = true
 
   if (typeof parametersOrPublisherName === 'string') {
     publisherName = parametersOrPublisherName
@@ -55,6 +56,9 @@ function makeCert (parametersOrPublisherName, certFilePath, program) {
     certFilePath = parametersOrPublisherName.certFilePath
     certFileName = parametersOrPublisherName.certFileName || publisherName
     program = parametersOrPublisherName.program
+    if (typeof parametersOrPublisherName.install === 'boolean') {
+      install = parametersOrPublisherName.install
+    }
   }
 
   if (typeof publisherName !== 'string') {
@@ -65,6 +69,7 @@ function makeCert (parametersOrPublisherName, certFilePath, program) {
     publisherName = `CN=${publisherName}`
   }
 
+  certFilePath = certFilePath || ''
   const cer = path.join(certFilePath, `${certFileName}.cer`)
   const pvk = path.join(certFilePath, `${certFileName}.pvk`)
   const pfx = path.join(certFilePath, `${certFileName}.pfx`)
@@ -79,12 +84,18 @@ function makeCert (parametersOrPublisherName, certFilePath, program) {
   // Ensure the target directory exists
   fs.ensureDirSync(certFilePath)
 
-  // Inform the user about the password
-  utils.log(chalk.green.bold('When asked to enter a password, please select "None".'))
+  // If the private key file doesn't exist, makecert.exe will generate one and prompt user to set password
+  if (!fs.existsSync(pvk)) {
+    utils.log(chalk.green.bold('When asked to enter a password, please select "None".'))
+  }
 
   return utils.executeChildProcess(makecertExe, makecertArgs)
     .then(() => utils.executeChildProcess(pk2pfx, pk2pfxArgs))
-    .then(() => utils.executeChildProcess('powershell.exe', installPfxArgs))
+    .then(() => {
+      if (install) {
+        utils.executeChildProcess('powershell.exe', installPfxArgs)
+      }
+    })
     .then(() => {
       program.devCert = pfx
       return pfx


### PR DESCRIPTION
It would be nice for consuming apps to be able to call `makeCert` to create a certificate without adding it to the system's certificate store. Other than add flexibility, I'm not sure if there are other legitimate use cases, but without this an unprivileged user may run into an error like this:

```
Import-PfxCertificate : Access is denied. (Exception from HRESULT: 0x80070005

(E_ACCESSDENIED))
At line:1 char:1
+ Import-PfxCertificate -FilePath C:\Users\Jacob\AppData\Local\Temp\ele ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Import-PfxCertificate], UnauthorizedAccessException
    + FullyQualifiedErrorId : System.UnauthorizedAccessException,Microsoft.CertificateServices.Commands.ImportPfxCertificate
```