### PR TITLE
Add support for signing with P12 certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ These are all options for the CLI:
   --make-pri <true|false>                    Use makepri.exe (you don't need to unless you know you do)
   --windows-kit <windows-kit>                Path to the Windows Kit bin folder
   --dev-cert <dev-cert>                      Path to the developer certificate to use
+  --cert-pass <cert-pass>                    Password to use when signing the application (only necessary if a p12 certication is used)
   --desktop-converter <desktop-converter>    Path to the desktop converter tools
   --expanded-base-image <base-image>         Path to the expanded base image
   --makeappx-params <params>                 Additional parameters for Make-AppXPackage (example: --makeappx-params "/l","/d")
@@ -115,6 +116,7 @@ convertToWindowsStore({
    publisher: 'CN=developmentca',
    windowsKit: 'C:\\windowskit',
    devCert: 'C:\\devcert.pfx',
+   certPass: 'abcd',
    desktopConverter: 'C:\\desktop-converter-tools',
    expandedBaseImage: 'C:\\base-image.wim',
    makeappxParams: ['/l'],

--- a/bin/windowsstore.js
+++ b/bin/windowsstore.js
@@ -40,6 +40,7 @@ program
   .option('--publisher-display-name <publisherDisplayName>', 'Publisher display name to use')
   .option('--windows-kit <windows-kit>', 'Path to the Windows Kit bin folder')
   .option('--dev-cert <dev-cert>', 'Path to the developer certificate to use')
+  .option('--cert-pass <cert-pass>', 'Certification password')
   .option('--desktop-converter <desktop-converter>', 'Path to the desktop converter tools')
   .option('--expanded-base-image <base-image>', 'Path to the expanded base image')
   .option('--make-pri <true|false>', 'Use makepri.exe (you don\'t need to unless you know you do)', (i) => (i === 'true'))

--- a/lib/params.js
+++ b/lib/params.js
@@ -86,6 +86,15 @@ module.exports = function (program) {
         }
 
         Object.assign(program, answers)
+      })
+      .then(() => {
+        // Verify optional parameters
+        if (program.devCert.match(/.p12$/i)) {
+          if (!program.certPass) {
+            utils.debug(`Error: Using a P12 certification file but the password is missing`)
+            return reject(new Error('No certificate password specified!'))
+          }
+        }
         resolve()
       })
   })

--- a/lib/sign.js
+++ b/lib/sign.js
@@ -115,7 +115,12 @@ function signAppx (program) {
 
     const pfxFile = program.devCert
     const appxFile = path.join(program.outputDirectory, `${program.packageName}.appx`)
-    const params = ['sign', '-f', pfxFile, '-fd', 'SHA256', '-v'].concat(program.signtoolParams || [])
+    let params = ['sign', '-f', pfxFile, '-fd', 'SHA256', '-v']
+    if (program.certPass) {
+      params.push('-p', program.certPass)
+    }
+
+    params = params.concat(program.signtoolParams || [])
 
     utils.debug(`Using PFX certificate from: ${pfxFile}`)
     utils.debug(`Signing appx package: ${appxFile}`)

--- a/test/lib/sign.js
+++ b/test/lib/sign.js
@@ -63,6 +63,31 @@ describe('Sign', () => {
         })
     })
 
+    it('should pass along the certificate password', function () {
+      const programMock = {
+        inputDirectory: '/fakepath/to/input',
+        outputDirectory: '/fakepath/to/output',
+        windowsKit: '/fakepath/to/windows/kit/bin',
+        packageName: 'testapp',
+        devCert: 'fakepath/to/devcert.p12',
+        certPass: '12345'
+      }
+
+      mockery.registerMock('child_process', cpMock)
+
+      return sign.signAppx(programMock)
+        .then(() => {
+          const expectedScript = path.join(programMock.windowsKit, 'signtool.exe')
+          const expectedPfxFile = programMock.devCert
+          const expectedAppx = path.join(programMock.outputDirectory, `${programMock.packageName}.appx`)
+          const expectedParams = ['sign', '-f', expectedPfxFile, '-fd', 'SHA256', '-v', '-p', '12345', expectedAppx]
+
+          passedProcess.length.should.equal(1)
+          passedProcess[0].should.equal(expectedScript)
+          passedArgs[0].should.deep.equal(expectedParams)
+        })
+    })
+
     it('should reject if no certificate is present', function () {
       const programMock = {}
       return sign.signAppx(programMock).should.be.rejected


### PR DESCRIPTION
Attempted to fix #32 by checking for the presence of a P12 certificate and then requiring a password which is passed along to the `signtool.exe`.