### PR TITLE
Fix incorrect paths in make-pri

### DIFF
--- a/lib/makepri.js
+++ b/lib/makepri.js
@@ -17,9 +17,9 @@ function createConfig (program) {
     utils.log(chalk.bold.green('Creating priconfig...'))
 
     const makepri = path.join(program.windowsKit, 'makepri.exe')
-    const source = path.join(program.outputDirectory, 'pre-appx', 'priconfig.xml')
+    const source = path.join('pre-appx', 'priconfig.xml')
     const params = ['createconfig', '/cf', source, '/dq', 'en-US'].concat(program.createConfigParams || [])
-    const options = {cwd: path.join(program.outputDirectory, 'pre-appx')}
+    const options = {cwd: program.outputDirectory}
 
     utils.debug(`Using makepri.exe in: ${makepri}`)
     utils.debug(`Using pre-appx folder in: ${source}`)
@@ -44,10 +44,11 @@ function createPri (program) {
     utils.log(chalk.bold.green('Creating pri file...'))
 
     const makepri = path.join(program.windowsKit, 'makepri.exe')
-    const source = path.join(program.outputDirectory, 'pre-appx', 'priconfig.xml')
-    const destination = path.join(program.outputDirectory, 'pre-appx')
-    const params = ['new', '/pr', destination, '/cf', source].concat(program.createPriParams || [])
-    const options = {cwd: path.join(program.outputDirectory, 'pre-appx')}
+    const source = path.join('pre-appx', 'priconfig.xml')
+    const projectFolder = 'pre-appx'
+    const outFile = path.join('pre-appx', 'resources.pri')
+    const params = ['new', '/pr', projectFolder, '/cf', source, '/of', outFile].concat(program.createPriParams || [])
+    const options = {cwd: program.outputDirectory}
 
     utils.debug(`Using makepri.exe in: ${makepri}`)
     utils.debug(`Using pre-appx folder in: ${source}`)

--- a/test/lib/makepri.js
+++ b/test/lib/makepri.js
@@ -40,7 +40,7 @@ describe('Makepri', () => {
 
       require('../../lib/makepri')(programMock)
         .then(() => {
-          const exptectedTarget = path.join(programMock.outputDirectory, 'pre-appx', 'priconfig.xml')
+          const exptectedTarget = path.join('pre-appx', 'priconfig.xml')
           const expectedScript = path.join(programMock.windowsKit, 'makepri.exe')
           const expectedParams = ['createconfig', '/cf', exptectedTarget, '/dq', 'en-US']
 
@@ -65,10 +65,11 @@ describe('Makepri', () => {
 
       require('../../lib/makepri')(programMock)
         .then(() => {
-          const expectedOutput = path.join(programMock.outputDirectory, 'pre-appx')
-          const exptectedTarget = path.join(programMock.outputDirectory, 'pre-appx', 'priconfig.xml')
+          const expectedProject = 'pre-appx'
+          const exptectedTarget = path.join('pre-appx', 'priconfig.xml')
+          const expectedOutput = path.join('pre-appx', 'resources.pri')
           const expectedScript = path.join(programMock.windowsKit, 'makepri.exe')
-          const expectedParams = ['new', '/pr', expectedOutput, '/cf', exptectedTarget]
+          const expectedParams = ['new', '/pr', expectedProject, '/cf', exptectedTarget, '/of', expectedOutput]
 
           spawnedProcesses[1].passedProcess.should.equal(expectedScript)
           spawnedProcesses[1].passedArgs.should.deep.equal(expectedParams)


### PR DESCRIPTION
All of the paths being handed to `makepri.exe` were all trying to be relative from the project directory, but we're being run in the cwd of `pre-appx`. I'm attempting to use unplated app icons so I've updated these accordingly