### PR TITLE
Use npm dedupe instead of flatten-packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -254,11 +254,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
-    },
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
@@ -901,24 +896,6 @@
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
-      }
-    },
-    "flatten-packages": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/flatten-packages/-/flatten-packages-0.1.4.tgz",
-      "integrity": "sha1-7cXxrQm9utmKHmMyvSkX0NkzIZM=",
-      "requires": {
-        "colors": "0.6.2",
-        "commander": "2.1.0",
-        "semver": "2.2.1",
-        "wrench": "1.5.9"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
-        }
       }
     },
     "foreach": {
@@ -1884,11 +1861,6 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
-    "semver": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
-      "integrity": "sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM="
-    },
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
@@ -2118,11 +2090,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "wrench": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
-      "integrity": "sha1-QRaRxjqbJTGxcAJnJ5veyiOyFCo="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   ],
   "engineStrict": true,
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.0.0",
+    "npm": ">=4.4.0"
   },
   "author": "",
   "license": "MIT",
@@ -35,7 +36,6 @@
     "chalk": "^2.1.0",
     "commander": "^2.11.0",
     "debug": "^2.6.3",
-    "flatten-packages": "^0.1.4",
     "fs-extra": "^4.0.1",
     "inquirer": "^3.2.3",
     "lodash.defaults": "^4.2.0",

--- a/ps1/flattennpmmodules.ps1
+++ b/ps1/flattennpmmodules.ps1
@@ -14,21 +14,16 @@ If (-Not (Test-path $source)) {
     return "Source directory cannot be found"
 }
 
-$flattenbin = (get-item $PSScriptRoot).parent.FullName + '\node_modules\flatten-packages\bin\flatten'
-If (!(Test-Path $flattenbin)) {
-    $flattenbin = (get-item $PSScriptRoot).parent.FullName + '\..\flatten-packages\bin\flatten'
-}
-
 function flatMe([string]$path){
     if (!$path.EndsWith('\')) {
         $path = $path + '\'
     }
-    
+
     Write-Host "Getting subdirectories of: " $path
     Get-ChildItem $path -Directory | ForEach-Object {
         if($_.Name -eq 'node_modules'){
             Write-Host "Flattening: " $path
-            node $flattenbin $path
+            npm dedupe
         } else {
             flatMe($path + $_)
         }


### PR DESCRIPTION
It turns out that `flatten-packages` is unmaintained and has at least one insecure dependency – this PR updates `electron-windows-store` to use `npm dedupe` instead, which shooooould accomplish the same thing. 🤞 