### PR TITLE
Node 6 support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,11 @@ init:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "6.0"
+    - nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)
 install:
+  - ps: Install-Product node $env:nodejs_version
   - npm install
 
 # Post-install test scripts.

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -5,9 +5,9 @@ const fs = require('fs-extra')
 const chalk = require('chalk')
 const utils = require('./utils')
 
-module.exports = async function (program) {
+module.exports = function (program) {
   if (!program.assets) {
-    return
+    return Promise.resolve()
   }
 
   // Let's copy in the assets
@@ -18,13 +18,9 @@ module.exports = async function (program) {
 
   utils.debug(`Copying visual assets from ${source} to ${destination}`)
 
-  try {
-    await fs.copy(source, destination)
-  } catch (error) {
-    utils.debug(`Copying visual assets failed: ${JSON.stringify(error)}`)
-
-    throw error
-  }
-
-  utils.debug('Copying visual assets succeeded')
+  return fs.copy(source, destination)
+    .catch(error => {
+      utils.debug(`Copying visual assets failed: ${JSON.stringify(error)}`)
+      throw error
+    }).then(() => utils.debug('Copying visual assets succeeded'))
 }

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -6,9 +6,9 @@ const chalk = require('chalk')
 
 const utils = require('./utils')
 
-module.exports = async function (program) {
+module.exports = function (program) {
   if (!program.manifest) {
-    return
+    return Promise.resolve()
   }
 
   // Let's copy in the new manifest
@@ -19,11 +19,10 @@ module.exports = async function (program) {
 
   utils.debug(`Copying manifest from ${source} to ${destination}`)
 
-  try {
-    await fs.copy(source, destination)
-  } catch (error) {
-    utils.debug(`Could not overwrite manifest. Error: ${JSON.stringify(error)}`)
+  return fs.copy(source, destination)
+    .catch(error => {
+      utils.debug(`Could not overwrite manifest. Error: ${JSON.stringify(error)}`)
 
-    throw error
-  }
+      throw error
+    })
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "engineStrict": true,
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=6.0.0"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
AppVeyor is already configured to use Node 6. (Although it doesn't ~~for some reason in the 2.0.0 commit?~~ because it doesn't actually use `$env:nodejs_version`)

This is mostly so Electron Forge can update its dependency to the latest version of `electron-windows-store`.