### PR TITLE
fix: quote filepath for Import-PfxCertificate

### DIFF
--- a/lib/sign.js
+++ b/lib/sign.js
@@ -83,7 +83,7 @@ function makeCert (parametersOrPublisherName, certFilePath, program) {
 
   const pk2pfx = path.join(program.windowsKit, 'pvk2pfx.exe')
   const pk2pfxArgs = ['-pvk', pvk, '-spc', cer, '-pfx', pfx]
-  const installPfxArgs = ['Import-PfxCertificate', '-FilePath', pfx, '-CertStoreLocation', '"Cert:\\LocalMachine\\TrustedPeople"']
+  const installPfxArgs = ['Import-PfxCertificate', '-FilePath', `"${pfx}"`, '-CertStoreLocation', '"Cert:\\LocalMachine\\TrustedPeople"']
 
   // Ensure the target directory exists
   fs.ensureDirSync(certFilePath)


### PR DESCRIPTION
Installing the dev certificate via `Import-PfxCertificate` requires the path to be quoted, otherwise installation fails if the path contains whitespace.

I'm not sure what `pvk2pfx.exe` does and saw no more errors once I quoted `pfx` in `installPfxArgs` so I left it at that – but maybe it needs to be quoted in `pk2pfxArgs` too and I just didn't hit that code path?