### PR TITLE
Do not copy sample assets if custom assets are provided

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -115,8 +115,12 @@ function convertWithFileCopy (program) {
     utils.log(chalk.green.bold('Copying data...'))
     fs.copySync(manifestTemplate, manifest)
     utils.debug('Copied manifest template to destination')
-    fs.copySync(assetsTemplate, assets)
-    utils.debug('Copied asset template to destination')
+    if (program.assets) {
+      utils.debug('Not copying asset template to destination because custom assets are provided')
+    } else {
+      fs.copySync(assetsTemplate, assets)
+      utils.debug('Copied asset template to destination')
+    }
     fs.copySync(program.inputDirectory, app)
     utils.debug('Copied input app files to destination')
 


### PR DESCRIPTION
If the user wants to manage their own assets, we should not include our own. This just leads to bloat and to confusion.

Fixes https://github.com/felixrieseberg/electron-windows-store/issues/133