### PR TITLE
match only if devCert is provided

### DIFF
--- a/lib/params.js
+++ b/lib/params.js
@@ -83,7 +83,7 @@ module.exports = function (program) {
       })
       .then(() => {
         // Verify optional parameters
-        if (program.devCert.match(/.p12$/i)) {
+        if (program.devCert && program.devCert.match(/.p12$/i)) {
           if (!program.certPass) {
             utils.debug(`Error: Using a P12 certification file but the password is missing`)
             return reject(new Error('No certificate password specified!'))


### PR DESCRIPTION
Added a check to match only if devCert is provided as it may not be provided all the time

> If the AppX package is meant for Windows Store distribution, no need to sign the package with any certificate. The Windows Store will take care of signing it with a Microsoft certificate during the submission process.

[reference](https://githubmemory.com/repo/felixrieseberg/electron-windows-store/issues?cursor=Y3Vyc29yOnYyOpK5MjAxOC0xMS0xMFQwMTo0Mjo1OSswODowMM4WmwR2&pagination=next&page=4)