### PR TITLE
Support for providing a protocol URI scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ convertToWindowsStore({
    createPriParams: ['/b'],
    finalSay: function () {
      return new Promise((resolve, reject) => resolve())
-   }
+   },
+   protocol: "ghost.app"
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ convertToWindowsStore({
    makePri: true,
    createConfigParams: ['/a'],
    createPriParams: ['/b'],
+   protocol: "ghost-app",
    finalSay: function () {
      return new Promise((resolve, reject) => resolve())
-   },
-   protocol: "ghost.app"
+   }
 })
 ```
 

--- a/bin/windowsstore.js
+++ b/bin/windowsstore.js
@@ -28,7 +28,7 @@ program
   .option('-p, --package-version <version>', 'Version of the app package')
   .option('-n, --package-name <name>', 'Name of the app package')
   .option('--identity-name <name>', 'Name for identity')
-  .option('--package-display-name <displayName>', 'Dispay name of the package')
+  .option('--package-display-name <displayName>', 'Display name of the package')
   .option('--package-description <description>', 'Description of the package')
   .option('--package-background-color <color>', 'Background color for the app icon (example: #464646)')
   .option('-e, --package-executable <executablePath>', 'Path to the package executable')
@@ -47,6 +47,7 @@ program
   .option('--signtool-params <params>', 'Additional parameters for signtool.exe (example: --makeappx-params "/l","/d")', list)
   .option('--create-config-params <params>', 'Additional parameters for makepri.exe "createconfig" (example: --create-config-params "/l","/d")', list)
   .option('--create-pri-params <params>', 'Additional parameters for makepri.exe "new" (example: --create-pri-params "/l","/d")', list)
+  .option('--protocol <protocol>', 'Protocol scheme to start the application with.')
   .option('--verbose <true|false>', 'Enable debug mode')
   .parse(process.argv)
 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -140,10 +140,10 @@ function convertWithFileCopy (program) {
       result = result.replace(/\${packageDisplayName}/g, program.packageDisplayName || program.packageName)
       result = result.replace(/\${packageDescription}/g, program.packageDescription || program.packageName)
       result = result.replace(/\${packageBackgroundColor}/g, program.packageBackgroundColor || '#464646')
-      result = result.replace(/\${protocol}/g, `<uap:Extension Category="windows.protocol">
+      result = result.replace(/\${protocol}/g, program.protocol ? `<uap:Extension Category="windows.protocol">
           <uap:Protocol Name="${program.protocol}">
           </uap:Protocol>
-        </uap:Extension>` || '')
+        </uap:Extension>` : '')
 
       fs.writeFile(manifest, result, 'utf8', (err) => {
         if (err) {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -140,6 +140,10 @@ function convertWithFileCopy (program) {
       result = result.replace(/\${packageDisplayName}/g, program.packageDisplayName || program.packageName)
       result = result.replace(/\${packageDescription}/g, program.packageDescription || program.packageName)
       result = result.replace(/\${packageBackgroundColor}/g, program.packageBackgroundColor || '#464646')
+      result = result.replace(/\${protocol}/g, `<uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="${program.protocol}">
+          </uap:Protocol>
+        </uap:Extension>` || '')
 
       fs.writeFile(manifest, result, 'utf8', (err) => {
         if (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ const makepri = require('./makepri')
  * @property {[string]}  createConfigParams      - Additional parameters for makepri.exe createconfig
  * @property {[string]}  createPriParams         - Additional parameters for makepri.exe new
  * @property {function}  finalSay                - A function that is called before makeappx.exe executes. Accepts a promise.
+ * @property {string}    protocol                - Protocol in which to start the application with.
  *
  * @returns {Promise} - A promise that completes once the appx has been created
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ const makepri = require('./makepri')
  * @property {[string]}  createConfigParams      - Additional parameters for makepri.exe createconfig
  * @property {[string]}  createPriParams         - Additional parameters for makepri.exe new
  * @property {function}  finalSay                - A function that is called before makeappx.exe executes. Accepts a promise.
- * @property {string}    protocol                - Protocol in which to start the application with.
+ * @property {string}    protocol                - Protocol scheme to start the application with.
  *
  * @returns {Promise} - A promise that completes once the appx has been created
  */

--- a/template/appxmanifest.xml
+++ b/template/appxmanifest.xml
@@ -32,6 +32,9 @@
        Description="${packageDescription}">
         <uap:DefaultTile Wide310x150Logo="assets\SampleAppx.310x150.png" />
       </uap:VisualElements>
+      <Extensions>
+        ${protocol}
+      </Extensions>
     </Application>
   </Applications>
 </Package>


### PR DESCRIPTION
This PR adds support to package the appx with a [protocol URI scheme](https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-protocol).

For example, being able to launch your app with `my-app://somedatahere?token=abc123`

Electron has support for this, but the bundling process with appx takes over that functionality, so it must be bundled in the `AppManifest.xml` during packaging for the store in order to work.